### PR TITLE
Add capability to include routes and change service type

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: edge-gitops-vms
 description: Edge GitOps VMs
 type: application
-version: 0.1.0
+version: 0.2.0
 dependencies: [ ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # edge-gitops-vms
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Edge GitOps VMs
 
@@ -47,6 +47,10 @@ This chart is used to set up Edge GitOps VMs in conjunction with OpenShift Virtu
 | vmDefaults.ports[0].port | int | `22` |  |
 | vmDefaults.ports[0].protocol | string | `"TCP"` |  |
 | vmDefaults.ports[0].targetPort | int | `22` |  |
+| vmDefaults.routeTlsInsecureEdgeTerminationPolicy | string | `"none"` |  |
+| vmDefaults.routeTlsTermination | string | `"passthrough"` |  |
+| vmDefaults.routes | object | `{}` |  |
+| vmDefaults.serviceType | string | `"NodePort"` |  |
 | vmDefaults.sockets | int | `1` |  |
 | vmDefaults.sshpubkeyfield | string | `"publickey"` |  |
 | vmDefaults.sshsecret | string | `"secret/data/hub/vm-ssh"` |  |

--- a/templates/virtual-machines.yaml
+++ b/templates/virtual-machines.yaml
@@ -169,7 +169,31 @@ items:
     selector:
       vm.kubevirt.io/name: {{ $identifier }}
     sessionAffinity: None
-    type: NodePort
+    type: {{ (coalesce $vmr.serviceType $.Values.vmDefaults.serviceType) }}
+{{- range $route := $vmr.routes }}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: {{ coalesce $route.name $identifier }}
+    annotations:
+      argocd.argoproj.io/sync-wave: "2"
+    labels:
+      app: {{ $identifier }}
+      edge-gitops-role: {{ $vmr.role }}
+  spec:
+    to:
+      kind: Service
+      name: {{ $identifier }}
+      weight: 100
+    port:
+      targetPort: {{ $route.targetPort }}
+    tls:
+      termination: {{ coalesce $route.tlsTermination $.Values.vmDefaults.routeTlsTermination }}
+      insecureEdgeTerminationPolicy: {{ coalesce $route.tlsInsecureEdgeTerminationPolicy $.Values.vmDefaults.routeTlsInsecureEdgeTerminationPolicy }}
+{{- if $route.tlsSecretKeyName }}
+      tlsSecretKeyName: $route.routeTlsSecretKeyName
+{{- end }}
+{{- end }}
 kind: List
 metadata: {}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -30,13 +30,27 @@ vmDefaults:
   sshsecret: secret/data/hub/vm-ssh
   cloudinitsecret: secret/data/hub/cloud-init
   sshpubkeyfield: publickey
+  serviceType: NodePort
+  routeTlsInsecureEdgeTerminationPolicy: none
+  routeTlsTermination: passthrough
   # extraLabels is available for default extra labels to add to the virtualmachine
   # extraAnnotations is available for default extra labels to add to the virtualmachine
+  # The following provide defaults if they are not set in the route hash/map:
+  # routeTlsTermination
+  # routeTlsInsecureEdgeTerminationPolicy
+  # routeTlsSecretKeyName - no default
   ports:
     - name: ssh
       port: 22
       protocol: TCP
       targetPort: 22
+  routes: {}
+  # The following keys can be used/set in the route map
+  # name (defaults to vm-name)
+  # targetPort (no default)
+  # tlsTermination (defaults to routeTlsTermination from above)
+  # tlsInsecureEdgeTerminationPolicy (defaults to routeTlsInsecureEdgeTerminationPolicy above)
+  # tlsSecretKeyName - no default - not needed or used if not specified
 
 # Define the VMs you want to create with any specific attributes from vmDefaults
 # in an overrides file.


### PR DESCRIPTION
This adds two features to the chart:

1) Allow configuration of the service Type: for services (previously hardcoded to NodePort, which is still the default)
2) Ability to define route(s) to add to the VMs (at present the routes point to the service objects that are created as part of the chart)

This does not introduce backward incompatibiliies