### PR TITLE
Change the default machine type to q35

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,7 @@ vmDefaults:
   efi: false
   storage: 30Gi
   memory: 4Gi
-  machineType: pc-q35-rhel8.4.0
+  machineType: q35
   cores: 1
   sockets: 1
   threads: 1


### PR DESCRIPTION
Before, we explicitly set the machineType to pc-q35-rhel8.4.0 which is deprecated in 4.21. If we just set the default to 'q35' then Kubevirt will chose the most up to date version it can. If the user needs a specific version they can change the default or they can set it on a specific vm with the 'machineType' field.